### PR TITLE
Parallel Counter Creations

### DIFF
--- a/build-flow.sh
+++ b/build-flow.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done

--- a/build-ts.sh
+++ b/build-ts.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find ./src -name '*.d.ts' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`; done

--- a/package.json
+++ b/package.json
@@ -64,10 +64,12 @@
     ]
   },
   "scripts": {
-    "build": "npm run build-cjs && npm run build-flow && npm run build-ts",
+    "build": "npm run build-cjs && npm run build-flow-sh && npm run build-ts-sh",
     "build-cjs": "rimraf lib && babel src --ignore __tests__,__mocks__ -d lib",
     "build-flow": "find ./src -name '*.js' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`.flow; done",
+    "build-flow-sh": "sh build-flow.sh",
     "build-ts": "find ./src -name '*.d.ts' -not -path '*/__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/lib\\//g'`; done",
+    "build-ts-sh": "sh build-ts.sh",
     "watch": "jest --watch",
     "coverage": "jest --coverage --maxWorkers 2",
     "lint": "npm run eslint && npm run tslint && npm run tscheck",


### PR DESCRIPTION
if the counter is created in parallel save had chance to fail (had this on jenkins running `parallel` when buidling two branches at the same time). Now this should be safe

Also small chnage to package json so for windows  compatibility issue (`while` was not recognized even when running in bash shell)

Signed-off-by: Bartlomiej Specjalny <bspecjalny@gmail.com>