### PR TITLE
Feature/mongoose 5 duplication fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,6 @@ import mongoose, {
   type MongooseModel,
 } from 'mongoose';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { MongoError } from 'mongodb';
-
 export type AutoIncSettings = {|
   migrate?: boolean, // If this is to be run on a migration for existing records. Only set this on migration processes.
   model: string, // The model to configure the plugin for.
@@ -58,10 +55,7 @@ export function initialize(): void {
 }
 
 function isMongoDuplicateError(e: any): boolean {
-  return (
-    (e instanceof MongoError && e.code * 1 === 11000) ||
-    (e.name === 'MongoError' && e.code * 1 === 11000)
-  );
+  return e.code * 1 === 11000;
 }
 
 // Initialize plugin by creating counter collection in database.


### PR DESCRIPTION
So we run previous tests the 4+. And as we fixed issues last week, after upgrading to Mongoose 5 some errors came out. Now Mongoose wrapped the duplication error and changed it name of error and instance type. So i think only measurable check would be against the `code`.

This should address issue #7 